### PR TITLE
Adding github workflow with dce-ecr-action

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,30 @@
+# this will build and push an image to an ECR repo identified by
+# the REPOSITORY_NAME env setting. Any branch matching the pattern
+# */*, e.g., bugfix/some-bug, will be built and the resulting image
+# tagged, e.g., bugfix-some-bug
+
+name: Build and Push Image to ECR
+on:
+  push:
+    branches: [ master, stage, '*/*' ]
+
+env:
+  REPOSITORY_NAME: hdce/late-days-lti
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Build + Push
+        uses: harvard-edtech/dce-ecr-action@v1
+        with:
+          access_key_id:  ${{ secrets.PUSH_TO_ECR_AWS_ACCESS_KEY_ID }}
+          secret_access_key: ${{ secrets.PUSH_TO_ECR_AWS_SECRET_ACCESS_KEY }}
+          account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+          repo: ${{ env.REPOSITORY_NAME }}
+          region: ${{ secrets.AWS_DEFAULT_REGION }}
+          tags: ${{ github.sha }}
+          add_branch_tag: true


### PR DESCRIPTION
This workflow/action will build and push docker images to our ECR repos