### PR TITLE
Updting github workflow and adding app-specific Dockerfile

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build + Push
-        uses: harvard-edtech/dce-ecr-action@v1.2
+        uses: harvard-edtech/dce-ecr-action@v1.3
         with:
           access_key_id:  ${{ secrets.PUSH_TO_ECR_AWS_ACCESS_KEY_ID }}
           secret_access_key: ${{ secrets.PUSH_TO_ECR_AWS_SECRET_ACCESS_KEY }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:16.15-alpine3.14
+
+# setting this here prevents dev dependencies from installing
+ENV NODE_ENV production
+
+# copy the app code into the /app path
+COPY ./ /app
+WORKDIR /app
+
+# add git as a virtual package during the npm install
+# this is necessary in case any npm deps reference git repos
+RUN apk --update-cache add --virtual build-dependencies git \
+  && npm install -g npm \
+  && npm install --unsafe-perm \
+  && npm run build \
+  && apk del build-dependencies \
+  && rm -rf /var/cache/apk/*
+
+EXPOSE 8080
+ENV PORT 8080
+CMD ["npm", "start"]


### PR DESCRIPTION
* bumped to dce-ecr-action@v1.3
* images will now use nodejs v16 (was v14)
* will be picked up and used by the image-building github action
* allows independent testing/releasing images built from newer
  nodejs/alpine